### PR TITLE
rewrite to internalize buffers into Index and http endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,12 @@ streamvbyte = "0.1.1"
 structopt = "0.3.21"
 tracing = "0.1.26"
 tracing-appender = "0.1.2"
- 
+axum = { version = "0.4" }
+tokio = { version = "1", features = ["full"] }
+tower = { version = "0.4", features = ["util"] }
+serde_json = "1.0.79"
+parking_lot = "0.12.0"
+
 [build-dependencies]
 protobuf-codegen-pure = "2"
 

--- a/src/bin/create.rs
+++ b/src/bin/create.rs
@@ -1,7 +1,5 @@
 use structopt::StructOpt;
 
-use ioqp;
-
 #[derive(StructOpt, Debug)]
 #[structopt(name = "create", about = "create ioqp indexes")]
 struct Args {

--- a/src/bin/serve.rs
+++ b/src/bin/serve.rs
@@ -1,0 +1,127 @@
+use axum::{
+    extract::Query,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::{get, post},
+    Json, Router,
+};
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+#[structopt(name = "query", about = "serve ioqp indexes")]
+struct Args {
+    /// Path to ioqp input file
+    #[structopt(short, long, parse(from_os_str))]
+    index: std::path::PathBuf,
+    /// Port to bind
+    #[structopt(long)]
+    port: u16,
+}
+
+#[derive(serde::Deserialize)]
+enum QueryMode {
+    Fraction(f32),
+    Fixed(i64),
+}
+
+#[derive(serde::Deserialize)]
+struct QueryPayLoad {
+    query: String,
+    k: NonZeroUsize,
+    query_mode: QueryMode,
+}
+
+enum ServeError {
+    JoinWorkerError,
+}
+
+impl IntoResponse for ServeError {
+    fn into_response(self) -> Response {
+        let (status, error_message) = match self {
+            ServeError::JoinWorkerError => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Join worker thread error",
+            ),
+        };
+        let body = Json(serde_json::json!({
+            "error": error_message,
+        }));
+        (status, body).into_response()
+    }
+}
+type IndexType = ioqp::Index<ioqp::SimdBPandStreamVbyte>;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::from_args();
+
+    let index = IndexType::read_from_file(args.index)?;
+    let index = Arc::new(index);
+    let app = Router::new()
+        .route(
+            "/search",
+            post({
+                let index = Arc::clone(&index);
+                move |body| saerch_post(body, Arc::clone(&index))
+            }),
+        )
+        .route(
+            "/search",
+            get({
+                let index = Arc::clone(&index);
+                move |path| search(path, Arc::clone(&index))
+            }),
+        );
+
+    let addr = format!("0.0.0.0:{}", args.port).parse()?;
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await?;
+
+    Ok(())
+}
+
+async fn saerch_post(
+    Json(query): Json<QueryPayLoad>,
+    index: Arc<IndexType>,
+) -> Result<Json<ioqp::SearchResults>, ServeError> {
+    let result = tokio::task::spawn_blocking(move || {
+        let query_tokens: Vec<&str> = query.query.split_whitespace().collect();
+        match query.query_mode {
+            QueryMode::Fraction(rho) => {
+                index.query_fraction(&query_tokens, rho, None, query.k.get())
+            }
+            QueryMode::Fixed(postings_budget) => {
+                index.query_fixed(&query_tokens, postings_budget, None, query.k.get())
+            }
+        }
+    })
+    .await
+    .map_err(|_| ServeError::JoinWorkerError)?;
+
+    Ok(Json(result))
+}
+
+async fn search(
+    query: Query<QueryPayLoad>,
+    index: Arc<IndexType>,
+) -> Result<Json<ioqp::SearchResults>, ServeError> {
+    let query: QueryPayLoad = query.0;
+    let result = tokio::task::spawn_blocking(move || {
+        let query_tokens: Vec<&str> = query.query.split_whitespace().collect();
+        match query.query_mode {
+            QueryMode::Fraction(rho) => {
+                index.query_fraction(&query_tokens, rho, None, query.k.get())
+            }
+            QueryMode::Fixed(postings_budget) => {
+                index.query_fixed(&query_tokens, postings_budget, None, query.k.get())
+            }
+        }
+    })
+    .await
+    .map_err(|_| ServeError::JoinWorkerError)?;
+
+    Ok(Json(result))
+}

--- a/src/bin/task.rs
+++ b/src/bin/task.rs
@@ -1,5 +1,4 @@
 use structopt::StructOpt;
-use ioqp;
 
 #[derive(StructOpt, Debug)]
 #[structopt(name = "query", about = "query ioqp indexes")]
@@ -14,15 +13,14 @@ struct Args {
 
 // A block of work
 pub fn do_work() -> i32 {
-        let mut x = 0;
-        for _ in 0..10000000 {
-            x = 2*x+4-3*x+2-5*x+5;
-        }
-        return x as i32;
+    let mut x = 0;
+    for _ in 0..10000000 {
+        x = 2 * x + 4 - 3 * x + 2 - 5 * x + 5;
+    }
+    x as i32
 }
 
 fn main() -> anyhow::Result<()> {
-    
     //let (_non_blocking, _guard) = tracing_appender::non_blocking(std::io::stdout());
 
     let args = Args::from_args();
@@ -38,18 +36,18 @@ fn main() -> anyhow::Result<()> {
     let upper_bound = 100000;
 
     let mut hist = Vec::with_capacity(upper_bound);
- 
+
     let mut x = 0;
-    for i in 0..upper_bound {                    
+    for _i in 0..upper_bound {
         let start = std::time::Instant::now();
         let y = do_work();
         let elapsed = start.elapsed().as_micros() as u64;
         hist.push(elapsed);
         // Let 5ms be an abitrary "slow" time -- platform specific
-        x = x + y;
+        x += y;
     }
 
-    hist.sort();
+    hist.sort_unstable();
     let n = hist.len() as f32;
     let total_time = hist.iter().sum::<u64>();
     println!("# of samples: {}", hist.len());
@@ -59,9 +57,8 @@ fn main() -> anyhow::Result<()> {
     println!("99.9'th percntl.: {}µs", hist[(n * 0.999) as usize]);
     println!("            max.: {}µs", hist.last().unwrap());
     println!("       mean time: {:.1}µs", total_time as f32 / n);
-    
+
     println!("Dummy: {}", x);
 
     Ok(())
 }
-

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -27,16 +27,16 @@ impl Compressor for SimdBPandStreamVbyte {
         let bitpacker = SimdbpCompressor::new();
         let num_block_bits = bitpacker.num_bits_sorted(initial, input);
         output.write_u8(num_block_bits).unwrap();
-        let bytes = bitpacker.compress_sorted(initial, input, &mut output[..], num_block_bits);
+        let bytes = bitpacker.compress_sorted(initial, input, &mut *output, num_block_bits);
         bytes + 1
     }
     fn compress_sorted(initial: u32, input: &[u32], output: &mut [u8]) -> usize {
-        streamvbyte::encode_delta_to_buf(&input, &mut output[..], initial).unwrap()
+        streamvbyte::encode_delta_to_buf(input, &mut *output, initial).unwrap()
     }
     fn decompress_sorted_full(initial: u32, input: &[u8], output: &mut [u32]) -> usize {
         let bitpacker = SimdbpCompressor::new();
         let num_bits = unsafe { *input.get_unchecked(0) };
-        let compressed_len = num_bits as usize * BLOCK_LEN >> 3;
+        let compressed_len = (num_bits as usize * BLOCK_LEN) >> 3;
         let bytes =
             bitpacker.decompress_sorted(initial, &input[1..compressed_len + 1], output, num_bits);
         bytes + 1

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::collections::BinaryHeap;
 use std::collections::HashMap;
 use std::collections::HashSet;
 
@@ -9,9 +10,15 @@ use rayon::iter::ParallelIterator;
 use std::cmp::Reverse;
 
 use crate::ciff;
+use crate::impact;
 use crate::list;
+use crate::range::ByteRange;
+use crate::result::SearchResult;
 use crate::search;
+use crate::search::SearchScratch;
 use crate::util;
+use crate::ScoreType;
+use crate::SearchResults;
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct Index<C: crate::compress::Compressor> {
@@ -24,6 +31,8 @@ pub struct Index<C: crate::compress::Compressor> {
     max_doc_id: u32,
     num_postings: usize,
     impact_type: std::marker::PhantomData<C>,
+    #[serde(skip)]
+    search_bufs: parking_lot::Mutex<Vec<search::SearchScratch>>,
 }
 
 impl<Compressor: crate::compress::Compressor> Index<Compressor> {
@@ -63,10 +72,10 @@ impl<Compressor: crate::compress::Compressor> Index<Compressor> {
                         .map(|(impact, docs)| (impact.0, docs))
                         .collect();
                     all_postings.push((term, final_postings));
-                },
-                Some(ciff::CiffRecord::Document{ external_id, .. } ) => {
+                }
+                Some(ciff::CiffRecord::Document { external_id, .. }) => {
                     docmap.push(external_id);
-                },
+                }
                 None => break,
             }
         }
@@ -92,15 +101,24 @@ impl<Compressor: crate::compress::Compressor> Index<Compressor> {
             list_data.extend_from_slice(&term_data);
         }
 
+        let num_levels = uniq_levels.len();
+        let max_level = uniq_levels.into_iter().max().unwrap() as usize;
+        let search_bufs = parking_lot::Mutex::new(
+            (0..2048)
+                .map(|_| search::SearchScratch::from_index(max_level, max_doc_id))
+                .collect(),
+        );
+
         Ok(Index {
             docmap,
             vocab,
             list_data,
-            num_levels: uniq_levels.len(),
-            max_level: uniq_levels.into_iter().max().unwrap() as usize,
+            num_levels,
+            max_level,
             max_doc_id,
             num_postings,
             impact_type: std::marker::PhantomData,
+            search_bufs,
         })
     }
 
@@ -146,9 +164,203 @@ impl<Compressor: crate::compress::Compressor> Index<Compressor> {
     pub fn docmap(&self) -> &Vec<String> {
         &self.docmap
     }
-    
-    pub fn searcher(&self) -> search::Searcher<'_, Compressor> {
-        search::Searcher::with_index(&self)
+
+    fn determine_impact_segments<S: AsRef<str> + std::fmt::Debug + std::fmt::Display>(
+        &self,
+        data: &mut SearchScratch,
+        tokens: &[S],
+    ) -> usize {
+        // determine what to decompress
+        data.impacts.iter_mut().for_each(|i| i.clear());
+        tokens
+            .iter()
+            .filter_map(|tok| match self.impact_list(tok.as_ref()) {
+                Some(list) => {
+                    let mut start = list.start_byte_offset;
+                    Some(
+                        list.impacts
+                            .iter()
+                            .map(|ti| {
+                                let stop = start + ti.bytes as usize;
+                                data.impacts[ti.impact as usize].push(
+                                    impact::Impact::from_encoded_slice(
+                                        *ti,
+                                        ByteRange::new(start, stop),
+                                    ),
+                                );
+                                start += ti.bytes as usize;
+                                ti.count
+                            })
+                            .sum::<u32>(),
+                    )
+                }
+                None => {
+                    //println!("unknown query token '{}'", tok);
+                    None
+                }
+            })
+            .sum::<u32>() as usize
     }
 
+    fn process_impact_segments(&self, data: &mut SearchScratch, mut postings_budget: i64) {
+        data.accumulators.iter_mut().for_each(|x| *x = 0);
+        let impact_iter = data.impacts.iter_mut().rev().flat_map(|i| i.iter_mut());
+        for impact_group in impact_iter {
+            if postings_budget < 0 {
+                break;
+            }
+            let num_postings = impact_group.count() as i64;
+            let impact = impact_group.impact();
+            while let Some(chunk) = impact_group
+                .next_large_chunk::<Compressor>(&self.list_data, &mut data.large_decode_buf)
+            {
+                for doc_id in chunk {
+                    data.accumulators[*doc_id as usize] += impact as ScoreType;
+                    // let entry = self.accumulators.entry(*doc_id).or_insert(0);
+                    // *entry += impact;
+                }
+            }
+            while let Some(chunk) =
+                impact_group.next_chunk::<Compressor>(&self.list_data, &mut data.decode_buf)
+            {
+                for doc_id in chunk {
+                    data.accumulators[*doc_id as usize] += impact as ScoreType;
+                    // let entry = self.accumulators.entry(*doc_id).or_insert(0);
+                    // *entry += impact;
+                }
+            }
+            postings_budget -= num_postings;
+        }
+    }
+
+    fn determine_topk(&self, data: &mut SearchScratch, k: usize) -> Vec<SearchResult> {
+        let mut heap = BinaryHeap::with_capacity(k + 1);
+        let block_offset = k;
+        data.accumulators[..k]
+            .iter()
+            .enumerate()
+            .for_each(|(doc_id, score)| {
+                heap.push(SearchResult {
+                    doc_id: doc_id as u32,
+                    score: *score,
+                });
+            });
+        data.accumulators[k..]
+            .iter()
+            .enumerate()
+            .for_each(|(doc_id, &score)| {
+                let top = heap.peek().unwrap();
+                if top.score < score {
+                    heap.push(SearchResult {
+                        doc_id: (doc_id + block_offset) as u32,
+                        score,
+                    });
+                    heap.pop();
+                }
+            });
+        heap.into_sorted_vec()
+    }
+
+    fn determine_topk_chunks(&self, data: &mut SearchScratch, k: usize) -> Vec<SearchResult> {
+        let heap = &mut data.heap;
+        let accumulators = &mut data.accumulators;
+
+        heap.clear();
+        let block_offset = k;
+        accumulators[..k]
+            .iter()
+            .enumerate()
+            .for_each(|(doc_id, score)| {
+                heap.push(SearchResult {
+                    doc_id: doc_id as u32,
+                    score: *score,
+                });
+            });
+
+        const CHUNK_SIZE: u32 = 2048;
+
+        let mut doc_id = 0;
+        accumulators[k..]
+            .chunks(CHUNK_SIZE as usize)
+            .for_each(|scores| {
+                let threshold = heap.peek().unwrap().score;
+                //let max = scores.iter().max().unwrap();
+                let max_or_thres = unsafe { crate::util::determine_max(scores, threshold) };
+                if max_or_thres > threshold {
+                    scores.iter().for_each(|&score| {
+                        let top = heap.peek().unwrap();
+                        if top.score < score {
+                            heap.push(SearchResult {
+                                doc_id: (doc_id + block_offset as u32),
+                                score,
+                            });
+                            heap.pop();
+                        }
+                        doc_id += 1;
+                    });
+                } else {
+                    doc_id += CHUNK_SIZE;
+                }
+            });
+
+        // only alloc happens here
+        let mut result = Vec::new();
+        while let Some(elem) = heap.pop() {
+            result.push(elem);
+        }
+        result
+    }
+
+    pub fn query_fraction<S: AsRef<str> + std::fmt::Debug + std::fmt::Display>(
+        &self,
+        tokens: &[S],
+        rho: f32,
+        query_id: Option<usize>,
+        k: usize,
+    ) -> SearchResults {
+        let start = std::time::Instant::now();
+
+        let mut search_buf =
+            self.search_bufs.lock().pop().unwrap_or_else(|| {
+                search::SearchScratch::from_index(self.max_level, self.max_doc_id)
+            });
+
+        let total_postings = self.determine_impact_segments(&mut search_buf, tokens);
+        let postings_budget = (total_postings as f32 * rho).ceil() as i64;
+        self.process_impact_segments(&mut search_buf, postings_budget);
+        let topk = self.determine_topk(&mut search_buf, k);
+
+        self.search_bufs.lock().push(search_buf);
+        SearchResults {
+            topk,
+            took: start.elapsed(),
+            qid: query_id.unwrap_or_default(),
+        }
+    }
+
+    pub fn query_fixed<S: AsRef<str> + std::fmt::Debug + std::fmt::Display>(
+        &self,
+        tokens: &[S],
+        postings_budget: i64,
+        query_id: Option<usize>,
+        k: usize,
+    ) -> SearchResults {
+        let start = std::time::Instant::now();
+
+        let mut search_buf =
+            self.search_bufs.lock().pop().unwrap_or_else(|| {
+                search::SearchScratch::from_index(self.max_level, self.max_doc_id)
+            });
+
+        self.determine_impact_segments(&mut search_buf, tokens);
+        self.process_impact_segments(&mut search_buf, postings_budget);
+        let topk = self.determine_topk_chunks(&mut search_buf, k);
+
+        self.search_bufs.lock().push(search_buf);
+        SearchResults {
+            topk,
+            took: start.elapsed(),
+            qid: query_id.unwrap_or_default(),
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod impact;
 mod index;
 mod list;
 pub mod query;
+mod range;
 mod result;
 mod search;
 pub mod util;
@@ -13,5 +14,7 @@ pub mod util;
 pub use compress::SimdBPandStreamVbyte;
 pub use compress::Uncompressed;
 pub use index::Index;
+pub use range::ByteRange;
+pub use result::SearchResults;
 
 type ScoreType = i16;

--- a/src/range.rs
+++ b/src/range.rs
@@ -1,0 +1,32 @@
+use std::ops::Index;
+
+#[derive(Debug)]
+pub struct ByteRange {
+    start: usize,
+    stop: usize,
+}
+
+impl ByteRange {
+    pub fn new(start: usize, stop: usize) -> Self {
+        Self { start, stop }
+    }
+
+    pub fn from_slice(data: &[u8]) -> Self {
+        Self {
+            start: 0,
+            stop: data.len(),
+        }
+    }
+
+    pub fn advance(&mut self, bytes: usize) {
+        self.start += bytes;
+    }
+}
+
+impl Index<&ByteRange> for [u8] {
+    type Output = [u8];
+
+    fn index(&self, range: &ByteRange) -> &Self::Output {
+        &self[..][range.start..range.stop]
+    }
+}

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,7 +1,7 @@
-use std::io::Write;
 use std::cmp::Ordering;
+use std::io::Write;
 
-#[derive(Eq)]
+#[derive(Eq, serde::Serialize, Debug)]
 pub struct SearchResult {
     pub doc_id: u32,
     pub score: crate::ScoreType,
@@ -25,6 +25,7 @@ impl PartialEq for SearchResult {
     }
 }
 
+#[derive(serde::Serialize)]
 pub struct SearchResults {
     pub topk: Vec<SearchResult>,
     pub took: std::time::Duration,
@@ -32,16 +33,30 @@ pub struct SearchResults {
 }
 
 impl SearchResults {
-
-    pub fn to_trec_file(&self, id_map: &Vec<String>, mut output: &std::fs::File) {
+    pub fn to_trec_file(&self, id_map: &[String], mut output: &std::fs::File) {
         for (rank, res) in self.topk.iter().enumerate() {
-            writeln!(output, "{} Q0 {} {} {} ioqp", self.qid, id_map[res.doc_id as usize], rank+1, res.score).unwrap();
+            writeln!(
+                output,
+                "{} Q0 {} {} {} ioqp",
+                self.qid,
+                id_map[res.doc_id as usize],
+                rank + 1,
+                res.score
+            )
+            .unwrap();
         }
     }
 
-    pub fn _to_tsv_file(&self, id_map: &Vec<String>, mut output: &std::fs::File) {
+    pub fn _to_tsv_file(&self, id_map: &[String], mut output: &std::fs::File) {
         for (rank, res) in self.topk.iter().enumerate() {
-            writeln!(output, "{} {} {}", self.qid, id_map[res.doc_id as usize], rank+1).unwrap();
+            writeln!(
+                output,
+                "{} {} {}",
+                self.qid,
+                id_map[res.doc_id as usize],
+                rank + 1
+            )
+            .unwrap();
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,6 +7,11 @@ pub fn progress_bar(name: &str, limit: usize) -> indicatif::ProgressBar {
 }
 
 #[cfg(target_feature = "avx2")]
+/// determine max fast
+///
+/// # Safety
+///
+/// this works hopefully
 pub unsafe fn determine_max(scores: &[i16], threshold: i16) -> i16 {
     use std::arch::x86_64::*;
     union SimdToArray {
@@ -24,6 +29,11 @@ pub unsafe fn determine_max(scores: &[i16], threshold: i16) -> i16 {
 }
 
 #[cfg(not(target_feature = "avx2"))]
+/// determine max fast
+///
+/// # Safety
+///
+/// this works hopefully
 pub unsafe fn determine_max(scores: &[i16], threshold: i16) -> i16 {
     use std::arch::x86_64::*;
     union SimdToArray {
@@ -32,9 +42,8 @@ pub unsafe fn determine_max(scores: &[i16], threshold: i16) -> i16 {
     }
     let mut threshold = SimdToArray {
         simd: _mm_set_epi16(
-                  threshold, threshold, threshold, threshold, threshold, threshold, threshold,
-                  threshold,
-              ),
+            threshold, threshold, threshold, threshold, threshold, threshold, threshold, threshold,
+        ),
     };
     scores.chunks_exact(8).for_each(|chunk| {
         let data_chunk = _mm_loadu_epi16(&chunk[0]);


### PR DESCRIPTION
This rewrites some stuff to get rid of the search and instead do things inside the Index and have a bunch of search scratch space objects that different threads can use

also adds an HTTP endpoint for running concurrent queries in a realistic scenario

also fixes lots of clippy warnings