### PR TITLE
CLI for quant bits

### DIFF
--- a/src/bin/create.rs
+++ b/src/bin/create.rs
@@ -18,13 +18,16 @@ struct Args {
     /// BM25 b parameter
     #[structopt(long, default_value = "0.4")]
     bm25_b: f32,
+    /// Number of bits to use for index quantization
+    #[structopt(short, long, default_value = "8")]
+    quant_bits: u32,
 }
 
 fn main() -> anyhow::Result<()> {
     let args = Args::from_args();
 
     let index = if args.quantize {
-        ioqp::Index::<ioqp::SimdBPandStreamVbyte>::quantize_from_ciff_file(args.input, args.bm25_k1, args.bm25_b)
+        ioqp::Index::<ioqp::SimdBPandStreamVbyte>::quantize_from_ciff_file(args.input, args.quant_bits, args.bm25_k1, args.bm25_b)
     } else {
          ioqp::Index::<ioqp::SimdBPandStreamVbyte>::from_ciff_file(args.input)
     }?;

--- a/src/index.rs
+++ b/src/index.rs
@@ -39,6 +39,7 @@ pub struct Index<C: crate::compress::Compressor> {
 impl<Compressor: crate::compress::Compressor> Index<Compressor> {
     pub fn quantize_from_ciff_file<P: AsRef<std::path::Path> + std::fmt::Debug>(
         input_file_name: P,
+        quant_bits: u32,
         bm25_k1: f32,
         bm25_b: f32,
     ) -> anyhow::Result<Self> {
@@ -109,7 +110,7 @@ impl<Compressor: crate::compress::Compressor> Index<Compressor> {
 
         // (3) We now have the index-wide max_score, and the score for each impact
         // Quantize and organize
-        let quantizer = score::LinearQuantizer::new(max_score);
+        let quantizer = score::LinearQuantizer::new(max_score, quant_bits);
 
         for (idx, plist) in temp_idx.iter().enumerate() {
             let mut posting_map: BTreeMap<Reverse<u16>, Vec<u32>> = BTreeMap::new();

--- a/src/score.rs
+++ b/src/score.rs
@@ -31,7 +31,6 @@ impl BM25 {
     }
 }
 
-const QUANT_BITS:u32 = 8;
 
 #[derive(Clone, Copy)]
 pub struct LinearQuantizer {
@@ -41,10 +40,10 @@ pub struct LinearQuantizer {
 
 impl LinearQuantizer {
 
-    pub fn new(global_max: f32) -> LinearQuantizer {
+    pub fn new(global_max: f32, quant_bits: u32) -> LinearQuantizer {
         LinearQuantizer {
             global_max,
-            scale: (1_u32 << (QUANT_BITS)) as f32 / global_max,
+            scale: (1_u32 << (quant_bits)) as f32 / global_max,
         }
     }
 


### PR DESCRIPTION
Allows the bits used for quantization to be read from the CLI with 8 bits the default.