### PR TITLE
Fix results

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -459,7 +459,7 @@ impl<Compressor: crate::compress::Compressor> Index<Compressor> {
         while let Some(elem) = heap.pop() {
             result.push(elem);
         }
-        result
+        result.into_iter().rev().collect()
     }
 
     pub fn query_fraction<S: AsRef<str> + std::fmt::Debug + std::fmt::Display>(


### PR DESCRIPTION
The results heap will pop elements out in reverse order; we need to reverse the results vector to get the top-k correctly.