### PR TITLE
Rework to configurable accumulator type

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -435,8 +435,7 @@ impl<Compressor: crate::compress::Compressor> Index<Compressor> {
             .chunks(CHUNK_SIZE as usize)
             .for_each(|scores| {
                 let threshold = heap.peek().unwrap().score;
-                //let max = scores.iter().max().unwrap();
-                let max_or_thres = unsafe { crate::util::determine_max(scores, threshold) };
+                let max_or_thres = crate::util::determine_max(scores, threshold);
                 if max_or_thres > threshold {
                     scores.iter().for_each(|&score| {
                         let top = heap.peek().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,4 +18,6 @@ pub use index::Index;
 pub use range::ByteRange;
 pub use result::SearchResults;
 
-type ScoreType = i16;
+// Configurable: The data type for accumulating scores.
+type ScoreType = u16;
+

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,5 @@
+use crate::ScoreType;
+
 pub fn progress_bar(name: &str, limit: usize) -> indicatif::ProgressBar {
     let pb = indicatif::ProgressBar::new(limit as u64);
     pb.set_draw_delta(limit as u64 / 200);
@@ -12,7 +14,7 @@ pub fn progress_bar(name: &str, limit: usize) -> indicatif::ProgressBar {
 /// # Safety
 ///
 /// this works hopefully
-pub unsafe fn determine_max(scores: &[i16], threshold: i16) -> i16 {
+pub unsafe fn _determine_max_i16(scores: &[i16], threshold: i16) -> i16 {
     use std::arch::x86_64::*;
     union SimdToArray {
         array: [i16; 16],
@@ -34,7 +36,7 @@ pub unsafe fn determine_max(scores: &[i16], threshold: i16) -> i16 {
 /// # Safety
 ///
 /// this works hopefully
-pub unsafe fn determine_max(scores: &[i16], threshold: i16) -> i16 {
+pub unsafe fn _determine_max_i16(scores: &[i16], threshold: i16) -> i16 {
     use std::arch::x86_64::*;
     union SimdToArray {
         array: [i16; 8],
@@ -51,3 +53,15 @@ pub unsafe fn determine_max(scores: &[i16], threshold: i16) -> i16 {
     });
     *threshold.array.iter().max().unwrap()
 }
+
+// Simple max finding via cloned
+pub fn determine_max(scores: &[ScoreType], threshold: ScoreType) -> ScoreType {
+    scores.iter().cloned().max().unwrap().max(threshold)
+}
+
+// Simple max finding in place
+pub fn determine_max_simple(scores: &[ScoreType], threshold: ScoreType) -> ScoreType {
+    *scores.iter().max().unwrap().max(&threshold)
+}
+
+


### PR DESCRIPTION
This PR simplifies the top-k accumulation logic (based on the recent benchmarks) to avoid explicit SIMD computations and lets the compiler manage it on its own.

This also means the user can now configure the accumulator type (default is now `u16`) in `lib.rs` to suit their data.

Closes #18.