### PR TITLE
Add lints and fix warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ bincode = "1.3.3"
 bitpacking = "0.8.4"
 byteorder = "1.4.3"
 indicatif = { version = "0.16.2", features = ["rayon"] }
-protobuf = "2.24.1"
+protobuf = "2.27.1"
 rayon = "1.5.1"
 serde = { version = "1.0.126", features = ["derive"] }
 serde_bytes = "0.11.5"

--- a/build.rs
+++ b/build.rs
@@ -17,6 +17,13 @@ fn main() {
     let code = read_to_string(&path).expect("Failed to read generated file");
     let mut writer = BufWriter::new(File::create(path).unwrap());
     for line in code.lines() {
+        let mut line = line.to_string();
+        // Fix hidden lifetime parameters in generated types.
+        // The `elided_lifetimes_in_paths` lint is a crate level lint, rather than enable it crate
+        // wide we fix the warnings with the generated code.
+        if line.ends_with("::ReflectValueRef {") {
+            line = line.replace("ReflectValueRef", "ReflectValueRef<'_>");
+        }
         if !line.contains("//!") && !line.contains("#!") {
             writer
                 .write_all(line.as_bytes())

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -20,6 +20,7 @@ pub trait Compressor {
     fn decompress_sorted(initial: u32, input: &[u8], output: &mut [u32]) -> usize;
 }
 
+#[derive(Debug)]
 pub struct SimdBPandStreamVbyte;
 
 impl Compressor for SimdBPandStreamVbyte {
@@ -48,7 +49,9 @@ impl Compressor for SimdBPandStreamVbyte {
 
 use byteorder::LittleEndian;
 
+#[derive(Debug)]
 pub struct Uncompressed;
+
 impl Compressor for Uncompressed {
     fn compress_sorted_full(_initial: u32, input: &[u32], mut output: &mut [u8]) -> usize {
         for val in input {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_debug_implementations, rust_2018_idioms, clippy::pedantic)]
 #![feature(stdsimd)]
 
 mod ciff;

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,5 +1,6 @@
 use std::io::BufRead;
 
+#[derive(Debug)]
 pub struct Query {
     pub id: usize,
     pub tokens: Vec<String>,

--- a/src/result.rs
+++ b/src/result.rs
@@ -25,7 +25,7 @@ impl PartialEq for SearchResult {
     }
 }
 
-#[derive(serde::Serialize)]
+#[derive(serde::Serialize, Debug)]
 pub struct SearchResults {
     pub topk: Vec<SearchResult>,
     pub took: std::time::Duration,


### PR DESCRIPTION
This also fixes warning in generated protobuf types for `elided_lifetimes_in_paths`. It was decided to fix this in build.rs rather than allowing the `elided_lifetimes_in_paths` lint which must be done for the entire crate. This is why the lint wasn't added directly to `src/ciff/proto.rs` like all the other ones are. (actually adding `elided_lifetimes_in_paths` to src/ciff/proto.rs works but it produces a warning that `elided_lifetimes_in_paths` is crate level only.)

Another option to fix this would be to split the generated protobuf code into its own crate and enable `elided_lifetimes_in_paths` there, but I think that uses cargo workspaces, which seemed like overkill for this project currently.

Fixing the generated code via build.rs is brittle, but it seemed like the better option in this case.