### PR TITLE
Rework warmup to single terms from input queries

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -518,4 +518,14 @@ impl<Compressor: crate::compress::Compressor> Index<Compressor> {
             qid: query_id.unwrap_or_default(),
         }
     }
+
+    pub fn query_warmup(&self, tokens: &[Term]) {
+        let postings_budget = 0;
+        let mut search_buf = self.search_bufs.lock().pop().unwrap_or_else(|| {
+            search::SearchScratch::from_index(self.max_level, self.max_term_weight, self.max_doc_id)
+        });
+        self.determine_impact_segments(&mut search_buf, tokens);
+        self.process_impact_segments(&mut search_buf, postings_budget);
+        self.search_bufs.lock().push(search_buf);
+    }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,12 +1,31 @@
 use std::io::BufRead;
 use std::collections::HashMap;
+use std::cmp::Ordering;
 
 pub const MAX_TERM_WEIGHT:usize = 32;
 
-#[derive(serde::Serialize, serde::Deserialize, Debug)]
+#[derive(Eq, Clone, serde::Serialize, serde::Deserialize, Debug)]
 pub struct Term {
     pub token: String,
     pub freq: u32,
+}
+
+impl PartialEq for Term {
+    fn eq(&self, other: &Self) -> bool {
+        self.token == other.token
+    }
+}
+
+impl Ord for Term {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other.token.cmp(&self.token)
+    }
+}
+
+impl PartialOrd for Term {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
@@ -82,5 +101,3 @@ pub fn read_queries<P: AsRef<std::path::Path> + std::fmt::Debug>(
 
     Ok(queries)
 }
-
-


### PR DESCRIPTION
This reduces the warmup process to a unique list of single term queries
with minimal processing in similar terms of
`index::query_{fixed,fraction}` methods.

See #4